### PR TITLE
feat(ci): opt into OSRB License Risk Triage workflow

### DIFF
--- a/.github/workflows/osrb.yml
+++ b/.github/workflows/osrb.yml
@@ -1,0 +1,20 @@
+name: OSRB License Risk Triage
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  triage:
+    uses: NVIDIA-Omniverse/sectools-skills/.github/workflows/osrb-triage.yml@v1
+    with:
+      product-name: simready-foundation
+      # Advisory-only during initial adoption: post the PR comment and Job
+      # Summary on every PR, but never block the merge. Remove this override
+      # (or set to 'true') once known high-risk deps are resolved.
+      gate-on-high: 'false'


### PR DESCRIPTION
## Summary

Adds `.github/workflows/osrb.yml` to opt this repo into the OSRB License Risk Triage GitHub Action ([NVIDIA-Omniverse/sectools-skills@v1](https://github.com/NVIDIA-Omniverse/sectools-skills/releases/tag/v1.0.0)).

After this lands, future PRs to `main` opened by NVIDIA-org contributors get:
- A sticky PR comment with license-risk verdict (Tier 0–4)
- A rendered verdict in the Actions tab Job Summary
- An `osrb-out/` artifact bundle (OSRB packet, NVBug draft, written source offer when applicable)
- A gate on Tier 1a/1b copyleft / high-risk licenses

Running in **advisory-only mode** (`gate-on-high: 'false'`) during initial adoption — the comment posts but the gate never blocks the merge. Flip to `'true'` once known high-risk deps are resolved.

## ⚠️ This PR does not exercise the workflow itself

Two GitHub-fundamental reasons:
1. **New workflow files on fork-PR head branches don't auto-trigger.** GitHub security model. The workflow starts running after this PR is merged.
2. **Fork PRs can't fetch internal reusable workflows.** `sectools-skills` is internal-visibility within the NVIDIA enterprise; the GITHUB_TOKEN on a fork PR doesn't carry enterprise auth.

Once merged, all PRs to `main` opened from branches within the `nvidia` or `NVIDIA-Omniverse` orgs will trigger OSRB triage normally. External-contributor (non-NVIDIA) fork PRs will silently skip the OSRB job — those changes require manual OSRB review by a maintainer at merge time.

## Pre-merge verification

If you want to confirm the workflow actually runs before merging, the cleanest way is:
1. Merge this PR (the workflow file lands on main)
2. Open a follow-up PR from a branch in `nvidia/simready-foundation` (not a fork) with any trivial change
3. Watch the `OSRB License Risk Triage / triage / triage` and `… / triage / comment` checks fire on that PR

## Reference

- Live demo on a sister repo: [NVIDIA-Omniverse/omni-scheduler#27](https://github.com/NVIDIA-Omniverse/omni-scheduler/pull/27) — shows the sticky comment, Job Summary, and artifact for an `LGPL` dependency (`psycopg2-binary`)
- Action source + design docs: https://github.com/NVIDIA-Omniverse/sectools-skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)