### PR TITLE
Fix VM.TEX.002: classify texture inputs by color vs non-color data

### DIFF
--- a/nv_core/sr_specs/docs/capabilities/visualization/materials/validation.py
+++ b/nv_core/sr_specs/docs/capabilities/visualization/materials/validation.py
@@ -74,10 +74,27 @@ class VisualMaterialsCapabilityChecker(BaseRuleChecker):
     }
 
     # Color space requirements (VM.TEX.002)
+    # Inputs carrying *color* data, which must be sRGB-encoded.
     colorspace_srgb_list = [
         "inputs:UV_VertexColor",
         "inputs:Set1SuperAlbedo",
         "inputs:Set2SuperAlbedo",
+        # OmniPBR color inputs
+        "inputs:diffuse_texture",
+        "inputs:emissive_color_texture",
+    ]
+
+    # Inputs carrying *non-color* data, which must be linear/raw.
+    colorspace_raw_list = [
+        "inputs:normalmap_texture",
+        "inputs:detail_normalmap_texture",
+        "inputs:clearcoat_normalmap_texture",
+        "inputs:ORM_texture",
+        "inputs:ao_texture",
+        "inputs:metallic_texture",
+        "inputs:reflectionroughness_texture",
+        "inputs:opacity_texture",
+        "inputs:emissive_mask_texture",
     ]
 
     # Texture size limit (VM.TEX.001)
@@ -486,7 +503,7 @@ class VisualMaterialsCapabilityChecker(BaseRuleChecker):
                 color_space = attr.GetColorSpace()
                 attr_name = attr.GetName()
 
-                # Check if this attribute requires sRGB color space
+                # Color inputs must be sRGB-encoded
                 if attr_name in self.colorspace_srgb_list:
                     if color_space != "sRGB":
                         self._AddFailedCheck(
@@ -495,8 +512,8 @@ class VisualMaterialsCapabilityChecker(BaseRuleChecker):
                             requirement=cap.MaterialsRequirements.VM_TEX_002,
                         )
                         errors.append(f"Incorrect color space for {attr_name}: {color_space} (expected sRGB)")
-                else:
-                    # All other attributes should use 'raw' color space
+                # Non-color data inputs must be linear/raw
+                elif attr_name in self.colorspace_raw_list:
                     if color_space != "raw":
                         self._AddFailedCheck(
                             message=f"Attribute '{attr_name}' has color space '{color_space}', expected 'raw'",
@@ -504,6 +521,16 @@ class VisualMaterialsCapabilityChecker(BaseRuleChecker):
                             requirement=cap.MaterialsRequirements.VM_TEX_002,
                         )
                         errors.append(f"Incorrect color space for {attr_name}: {color_space} (expected raw)")
+                else:
+                    # Unclassified input: warn rather than guess. Assuming 'raw'
+                    # here would fail correctly-authored color inputs.
+                    self._AddWarning(
+                        message=(
+                            f"Attribute '{attr_name}' has color space '{color_space}' but is not "
+                            f"classified as color or non-color data; skipping VM.TEX.002 check"
+                        ),
+                        at=prim,
+                    )
 
         return errors
 


### PR DESCRIPTION
## Summary

`VM.TEX.002` requires sRGB for three attribute names that appear nowhere else in this repository, then falls back to requiring `raw` for every other input carrying `colorSpace` metadata. OmniPBR's albedo input `inputs:diffuse_texture` is not in that list, so **the check is inverted for albedo**: it accepts `raw` (incorrect) and rejects `sRGB` (correct).

This contradicts the requirement's own compliance table in `material-texture-colorspace.md`, which specifies "Base Color/Diffuse: sRGB".

## Evidence this is the rule, not the content

`inputs:diffuse_texture` is authored `sRGB` in **42 of 42** occurrences across all 47 USD files in `sample_content` — zero counterexamples.

Injecting three deliberate colorspace errors into a sample asset shows the inversion directly:

| Injected error | Before | After |
|---|---|---|
| `diffuse_texture` = `raw` (albedo not gamma-decoded) | **accepted** | caught |
| `ORM_texture` = `sRGB` | caught | caught |
| `normalmap_texture` = `sRGB` | caught | caught |

The pre-existing behavior lets the most visually damaging error through — an albedo tagged `raw` skips sRGB decode and renders washed out — while failing correctly-authored assets.

## Change

Replace the default-deny fallback with explicit classification:

- `colorspace_srgb_list` — inputs carrying color data (must be `sRGB`)
- `colorspace_raw_list` — inputs carrying non-color data (must be `raw`)
- unclassified inputs — **warn and skip**, rather than assume `raw`

The warn-and-skip branch is the substantive fix. Assuming `raw` for unrecognized inputs is what inverted the albedo check, and it would silently repeat for any shader input added in future.

The three existing names are retained; this change is additive.

## Effect on `sample_content`

Scoped to `VM.TEX.002` under `Prop-Robotics-Neutral`:

**Fixed (7):** `alcohol_a01`, `apple_a01`, `gen_appliance_toaster_v01_01`, `gen_cleaning_dishwand_v01_01`, `obs_electricians_large_tool_box_a01`, `obs_orange_a01`, `obs_orange_starter_a01`

**Still failing (3)** — genuine authoring errors, correctly caught before and after:
- `obs_light_bulb_01` — `opacity_texture` is `sRGB`
- `obs_small_sledge_hammer_a01` — `normalmap_texture` is `sRGB`
- `obs_workbench_tool_a01` — `normalmap_texture` is `sRGB`

**Regressions: none.**

Note that `apple_a01` is the asset used in `guides/validate_workflow.md`, whose expected output lists `VM.TEX.002` among "known gaps in the sample asset". After this change that failure no longer occurs, so that guide may warrant an update.

## Profile-agnostic

The change lives in the rule checker and references no profile. `VM.TEX.002` belongs to `FET006_BASE_MDL` only (not `FET006_BASE_USDPREVIEW`). Verified identical behavior under both `Prop-Robotics-Neutral` and `Prop-Robotics-Physx`: correct assets pass, injected errors are caught, in both.

## Consistency with the SimReady Blender add-on

The add-on's exporter maps Blender `Non-Color` to `raw` and everything else to `sRGB` (`blender_to_kit_color_space` in `material_utils.py`), and writes ORM as `raw` explicitly (`ot_simready_usdhook.py`). That produces sRGB albedo with raw normal/ORM — exactly what the corrected rule requires. Assets exported by the add-on now pass `VM.TEX.002`.

## Open question: OmniGlass

`glass_color_texture` and `normal_map_texture` are deliberately left **unclassified**, so they surface as warnings rather than pass or fail silently.

The add-on forces all OmniGlass textures to `raw`, commenting that the shader handles color space internally. I could not corroborate that from the MDL: `OmniGlass_Opacity.mdl` consumes `glass_color_texture` as color through `base::file_texture()` in `get_color()`, and there is no gamma handling anywhere in the OmniGlass MDL chain. The bound texture follows the `_a` albedo naming convention used by OmniPBR albedos that are authored `sRGB`.

This may be an exporter issue rather than intended behavior, so this PR does not encode either interpretation. Maintainer guidance welcome — if `raw` is correct for OmniGlass, those two inputs should be added to `colorspace_raw_list`.

## Testing

- Full `sample_content` sweep before/after (table above)
- Error-injection test confirming all three error classes are caught
- Cross-profile verification (`Prop-Robotics-Neutral`, `Prop-Robotics-Physx`)
- Ran with `simready-validate` 2026.4.9, `usd-core` 26.8, Python 3.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)