### PR TITLE
Fix ISA.001 to validate composition instead of the filesystem

### DIFF
--- a/nv_core/sr_specs/docs/capabilities/isaac_sim/composition/requirements/composition.md
+++ b/nv_core/sr_specs/docs/capabilities/isaac_sim/composition/requirements/composition.md
@@ -2,7 +2,7 @@
 
 | Code     | ISA.001 |
 |----------|---------|
-| Validator| |
+| Validator| CheckStage |
 | Compatibility | {compatibility}`OpenUSD` |
 | Tags     | {tag}`essential` |
 
@@ -115,6 +115,16 @@ def Xform "MyAsset" {
    - `{asset_name}_meshes.usd`: Contains geometry, materials (as "Looks"), and visual hierarchy
    - `{asset_name}_base.usd`: References the meshes file
    - `{asset_name}_physics.usd`: Contains physics materials, joints, and physics attributes
+
+   All three layers must end up composed into the stage. They are identified by their
+   `_base` / `_meshes` / `_physics` role suffix, so the `{asset_name}` stem does not have to
+   match the main asset file name exactly, and any of the `.usd`, `.usda`, or `.usdc` formats
+   may be used.
+
+   Robot assets validated under `Robot-Body-Isaac` use the robot payload layout described by
+   `RC.001` instead — `payloads/base.usda` plus `geometries.usd`, `instances.usda` and
+   `materials.usda`. Either layout satisfies this requirement, but an asset must match one of
+   them completely; a partial structure is a failure.
 3. **File Structure**: Organize the asset with the following directory structure:
    .. code-block:: text
 
@@ -134,6 +144,10 @@ def Xform "MyAsset" {
 7. **Reference Paths**: Use relative paths for all references and payloads to maintain portability
 8. **Default Prim**: Each USD file must have a properly set default prim
 9. **Metadata**: Set appropriate stage metadata including `upAxis = "Z"` and `metersPerUnit = 1.0`
+10. **Packaging**: The asset may be delivered either as an unpacked directory tree or as a single
+    `.usdz` package. Both are validated identically, from the composed stage rather than from the
+    surrounding directory listing: inside a `.usdz` the payload layers are archive members
+    (`myasset.usdz[payloads/myasset_base.usd]`) and there is no `payloads/` directory on disk.
 
 ## For More Information
 

--- a/nv_core/sr_specs/docs/capabilities/isaac_sim/composition/validation.py
+++ b/nv_core/sr_specs/docs/capabilities/isaac_sim/composition/validation.py
@@ -12,12 +12,58 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-from pathlib import Path
+import re
 
 import omni.capabilities as cap
 import usd_validation_nvidia
-from pxr import Kind, Usd, UsdGeom, UsdPhysics, UsdShade
+from pxr import Kind, Usd, UsdGeom
+
+# Payload layers are identified by *role* rather than by an exact filename, and the
+# roles are grouped into the two payload layouts that ISA.001 governs:
+#
+#   "prop"  - SimReady prop content, per this requirement's "How to comply" section:
+#             payloads/{asset_name}_base.usd + _meshes.usd + _physics.usd
+#             (packaged assets conventionally prefix the stem with an underscore)
+#   "robot" - the robot layout shared with RC.001, used by Robot-Body-Isaac:
+#             payloads/base.usda + geometries.usd + instances.usda + materials.usda
+#
+# An asset satisfies the payload-structure check when it completely matches either
+# layout. The two are disjoint: the prop patterns require an underscore before the
+# role word, so "payloads/base.usda" never matches the prop "base" role.
+#
+# The trailing ``(\]|$)`` makes every pattern match BOTH forms of layer identifier:
+#   on disk   ".../payloads/myasset_base.usd"
+#   in a usdz ".../myasset.usdz[payloads/myasset_base.usd]"
+_SUFFIX = r"\.usd[ac]?(\]|$)"
+
+_LAYOUTS = {
+    "prop": {
+        role: re.compile(rf"payloads/[^/]*_{role}{_SUFFIX}", re.IGNORECASE)
+        for role in ("base", "meshes", "physics")
+    },
+    "robot": {
+        role: re.compile(rf"payloads/{role}{_SUFFIX}", re.IGNORECASE)
+        for role in ("base", "geometries", "instances", "materials")
+    },
+}
+
+_LAYOUT_DESCRIPTIONS = {
+    "prop": "payloads/{asset_name}_base.usd + _meshes.usd + _physics.usd",
+    "robot": "payloads/base.usda + geometries.usd + instances.usda + materials.usda",
+}
+
+# Either layout's base layer is an acceptable target for the default prim's arc.
+_BASE_PATTERNS = (_LAYOUTS["prop"]["base"], _LAYOUTS["robot"]["base"])
+
+
+def _normalize(identifier: str) -> str:
+    """Normalize a layer identifier or asset path for role matching.
+
+    On-disk identifiers may use OS-native separators; usdz-internal layers are
+    always reported with forward slashes inside square brackets. Normalizing to
+    forward slashes lets one pattern match both.
+    """
+    return identifier.replace("\\", "/")
 
 
 @usd_validation_nvidia.register_rule("IsaacComposition")
@@ -53,40 +99,77 @@ class IsaacCompositionCapabilityChecker(usd_validation_nvidia.BaseRuleChecker):
         # Check for proper hierarchy organization
         self._check_hierarchy_organization(stage, default_prim)
 
+    @staticmethod
+    def _root_arc_asset_paths(default_prim: Usd.Prim) -> list:
+        """Asset paths of the reference and payload arcs authored on the default prim.
+
+        Read from the root layer's prim spec, so this reflects what the asset
+        itself declares rather than what composition happened to resolve.
+        """
+        root_layer = default_prim.GetStage().GetRootLayer()
+        prim_spec = root_layer.GetPrimAtPath(default_prim.GetPath())
+        if not prim_spec:
+            return []
+
+        arcs = prim_spec.referenceList.GetAddedOrExplicitItems()
+        arcs += prim_spec.payloadList.GetAddedOrExplicitItems()
+        return [_normalize(str(arc.assetPath)) for arc in arcs]
+
     def _check_payload_structure(self, stage: Usd.Stage, default_prim: Usd.Prim):
-        """Check if the asset has proper payload structure"""
-        stage_path = stage.GetRootLayer().identifier
-        if not stage_path:
+        """Check if the asset has proper payload structure.
+
+        Driven by the composed layer stack rather than the OS filesystem, so a
+        `.usdz` package -- whose ``payloads/`` layers live inside the archive and
+        therefore have no sibling directory on disk -- is validated the same way
+        as an unpacked asset.
+        """
+        # Union the composed layer stack with the arcs authored on the default
+        # prim. GetUsedLayers() alone would miss an unloaded payload when the
+        # stage was opened with a load rule other than LoadAll.
+        candidates = [_normalize(layer.identifier) for layer in stage.GetUsedLayers()]
+        candidates += self._root_arc_asset_paths(default_prim)
+
+        missing_by_layout = {
+            layout: [
+                role
+                for role, pattern in roles.items()
+                if not any(pattern.search(candidate) for candidate in candidates)
+            ]
+            for layout, roles in _LAYOUTS.items()
+        }
+
+        # The asset passes if it completely matches either recognized layout.
+        if any(not missing for missing in missing_by_layout.values()):
             return
 
-        stage_dir = Path(stage_path).parent
-        payloads_dir = stage_dir / "payloads"
+        # Otherwise report against the closest layout, so a nearly-complete asset
+        # gets told which layer it is actually missing rather than a generic error.
+        closest = min(missing_by_layout, key=lambda layout: len(missing_by_layout[layout]))
+        missing = missing_by_layout[closest]
 
-        # Check if payloads directory exists
-        if not payloads_dir.exists():
+        if len(missing) == len(_LAYOUTS[closest]):
+            accepted = " or ".join(
+                f"{layout} ({_LAYOUT_DESCRIPTIONS[layout]})" for layout in _LAYOUTS
+            )
             self._AddFailedCheck(
-                "Missing 'payloads/' directory for Isaac Sim composition.",
+                f"No recognized Isaac Sim payload structure found. Expected {accepted}.",
                 at=default_prim,
                 requirement=self.ISAAC_COMPOSITION_REQUIREMENT,
             )
             return
 
-        # Check for expected payload files
-        asset_name = Path(stage_path).stem
-        expected_files = ["geometries.usd", "base.usda", "instances.usda", "materials.usda"]
-
-        for expected_file in expected_files:
-            if not (payloads_dir / expected_file).exists():
-                self._AddFailedCheck(
-                    f"Missing expected payload file: payloads/{expected_file}",
-                    at=default_prim,
-                    requirement=self.ISAAC_COMPOSITION_REQUIREMENT,
-                )
+        for role in missing:
+            self._AddFailedCheck(
+                f"Incomplete {closest} Isaac Sim payload structure: no '{role}' layer is "
+                f"composed into the stage. Expected {_LAYOUT_DESCRIPTIONS[closest]}.",
+                at=default_prim,
+                requirement=self.ISAAC_COMPOSITION_REQUIREMENT,
+            )
 
     def _check_reference_structure(self, default_prim: Usd.Prim):
-        """Check if default prim has proper references and payloads"""
-        prim_spec = default_prim.GetStage().GetRootLayer().GetPrimAtPath(default_prim.GetPath())
-        if not prim_spec:
+        """Check if default prim has proper references and payloads."""
+        root_layer = default_prim.GetStage().GetRootLayer()
+        if not root_layer.GetPrimAtPath(default_prim.GetPath()):
             self._AddFailedCheck(
                 "Could not resolve prim spec for default prim.",
                 at=default_prim,
@@ -94,53 +177,34 @@ class IsaacCompositionCapabilityChecker(usd_validation_nvidia.BaseRuleChecker):
             )
             return
 
-        ref_list = prim_spec.referenceList.GetAddedOrExplicitItems()
-        has_base_ref = any(str(ref.assetPath) == "./payloads/base.usda" for ref in ref_list)
-
-        if not has_base_ref:
+        arc_paths = self._root_arc_asset_paths(default_prim)
+        if not any(pattern.search(path) for pattern in _BASE_PATTERNS for path in arc_paths):
             self._AddFailedCheck(
-                "Default prim missing reference to _base.usd payload file.",
+                "Default prim must reference or payload the base layer "
+                "(payloads/{asset_name}_base.usd or payloads/base.usda).",
                 at=default_prim,
                 requirement=self.ISAAC_COMPOSITION_REQUIREMENT,
             )
 
     def _check_hierarchy_organization(self, stage: Usd.Stage, default_prim: Usd.Prim):
-        """Check for proper Isaac Sim hierarchy organization"""
-        # Look for common Isaac Sim structure indicators
-        found_looks = False
-        found_meshes = False
-        found_visuals = False
-
-        # Check entire stage for expected scopes
+        """Check for proper Isaac Sim hierarchy organization."""
+        # The "Looks", "Meshes" and "Visuals" scopes may legitimately live inside a
+        # payload, so their absence is not an error here; only assert invisibility
+        # on the scopes that are actually present in the composed stage.
         for prim in Usd.PrimRange(stage.GetPseudoRoot()):
-            if prim.GetName() == "Looks" and prim.GetTypeName() == "Scope":
-                found_looks = True
-            elif prim.GetName() == "Meshes" and prim.GetTypeName() == "Scope":
-                found_meshes = True
-                # Check if Meshes scope is invisible
-                imageable = UsdGeom.Imageable(prim)
-                if imageable.GetVisibilityAttr():
-                    visibility = imageable.GetVisibilityAttr().Get()
-                    if visibility != UsdGeom.Tokens.invisible:
-                        self._AddFailedCheck(
-                            "Meshes scope should be invisible for proper Isaac Sim composition.",
-                            at=prim,
-                            requirement=self.ISAAC_COMPOSITION_REQUIREMENT,
-                        )
-            elif prim.GetName() == "Visuals" and prim.GetTypeName() == "Scope":
-                found_visuals = True
-                # Check if Visuals scope is invisible
-                imageable = UsdGeom.Imageable(prim)
-                if imageable.GetVisibilityAttr():
-                    visibility = imageable.GetVisibilityAttr().Get()
-                    if visibility != UsdGeom.Tokens.invisible:
-                        self._AddFailedCheck(
-                            "Visuals scope should be invisible for proper Isaac Sim composition.",
-                            at=prim,
-                            requirement=self.ISAAC_COMPOSITION_REQUIREMENT,
-                        )
+            if prim.GetName() not in ("Meshes", "Visuals") or prim.GetTypeName() != "Scope":
+                continue
 
-        # Warning if expected scopes are not found (may be in payloads)
-        if not (found_looks or found_meshes or found_visuals):
-            # This is a soft warning since these might be in payload files
-            pass  # Could add informational message if needed
+            visibility_attr = UsdGeom.Imageable(prim).GetVisibilityAttr()
+            if not visibility_attr:
+                continue
+
+            visibility = visibility_attr.Get()
+            # An unauthored visibility attribute resolves to None; treat only an
+            # explicitly visible scope as a failure.
+            if visibility is not None and visibility != UsdGeom.Tokens.invisible:
+                self._AddFailedCheck(
+                    f"{prim.GetName()} scope should be invisible for proper Isaac Sim composition.",
+                    at=prim,
+                    requirement=self.ISAAC_COMPOSITION_REQUIREMENT,
+                )

--- a/nv_core/sr_specs/tests/test_isaac_composition.py
+++ b/nv_core/sr_specs/tests/test_isaac_composition.py
@@ -1,0 +1,254 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the ISA.001 Isaac composition checker.
+
+The checker must judge an asset from its composed stage rather than from the
+surrounding directory listing, so that a `.usdz` package -- whose ``payloads/``
+layers are archive members with no counterpart on disk -- validates the same way
+as the equivalent unpacked directory tree.
+
+The `.usdz` fixture is built at test time rather than committed: `*.usdz` is a
+Git LFS pattern in this repository, and constructing the package here keeps the
+required layout readable in review and the fixture in sync with these tests.
+
+Run with:
+    pytest nv_core/sr_specs/tests/test_isaac_composition.py
+"""
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+from pxr import Kind, Sdf, Usd, UsdGeom, UsdUtils
+
+import simready.validate as sv
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CAPABILITIES_PATH = REPO_ROOT / "nv_core" / "sr_specs" / "docs" / "capabilities"
+FEATURES_PATH = REPO_ROOT / "nv_core" / "sr_specs" / "docs" / "features"
+PROFILES_PATH = REPO_ROOT / "nv_core" / "sr_specs" / "docs" / "profiles"
+
+ISA_001 = "com.nvidia.simready.ISA.001"
+
+SAMPLE_PROP = (
+    REPO_ROOT
+    / "sample_content"
+    / "common_assets"
+    / "props_general"
+    / "obs_workbench_tool_a01"
+    / "isaacsim_usd"
+    / "sm_obs_workbench_tool_a01_01.usd"
+)
+
+
+@pytest.fixture(scope="session")
+def checker_class():
+    """Load the validation implementation and return the ISA.001 checker class.
+
+    ``sv.initialize`` generates the ``omni.capabilities`` requirement enums from
+    the requirement docs and injects them, so the checker module cannot be
+    imported before it runs.
+    """
+    sv.initialize(
+        rules_and_requirements_paths=[CAPABILITIES_PATH],
+        features_paths=[FEATURES_PATH],
+        profiles_paths=[PROFILES_PATH],
+    )
+    module = importlib.import_module("capabilities.isaac_sim.composition.validation")
+    yield module.IsaacCompositionCapabilityChecker
+    sv.destroy()
+
+
+def isa_001_failures(checker_class, stage: Usd.Stage) -> list[str]:
+    """Run the checker over *stage* and return its ISA.001 failure messages."""
+    checker = checker_class()
+    checker.CheckStage(stage)
+    return [
+        str(getattr(issue, "message", issue))
+        for issue in checker.GetIssues()
+        if issue.requirement is not None and issue.requirement.code == ISA_001
+    ]
+
+
+def _define_default_prim(stage: Usd.Stage, path: str = "/MyAsset") -> Usd.Prim:
+    xform = UsdGeom.Xform.Define(stage, path)
+    stage.SetDefaultPrim(xform.GetPrim())
+    return xform.GetPrim()
+
+
+def build_isaac_asset(root: Path, meshes_visible: bool = False) -> Path:
+    """Author a minimal, correctly composed Isaac asset tree under *root*.
+
+    Layout matches the ISA.001 requirement doc:
+
+        myasset.usda
+        payloads/myasset_base.usd      <- referenced by the default prim
+        payloads/myasset_meshes.usd    <- referenced by the base layer
+        payloads/myasset_physics.usd   <- payloaded by the default prim
+    """
+    (root / "payloads").mkdir(parents=True, exist_ok=True)
+
+    meshes = Usd.Stage.CreateNew(str(root / "payloads" / "myasset_meshes.usd"))
+    _define_default_prim(meshes)
+    for scope_name in ("Looks", "Meshes", "Visuals"):
+        scope = UsdGeom.Scope.Define(meshes, f"/MyAsset/{scope_name}")
+        if scope_name == "Looks":
+            continue
+        visibility = UsdGeom.Tokens.inherited if meshes_visible else UsdGeom.Tokens.invisible
+        UsdGeom.Imageable(scope).CreateVisibilityAttr(visibility)
+    UsdGeom.Mesh.Define(meshes, "/MyAsset/Meshes/mesh_obj_01")
+    meshes.Save()
+
+    base = Usd.Stage.CreateNew(str(root / "payloads" / "myasset_base.usd"))
+    _define_default_prim(base).GetReferences().AddReference("./myasset_meshes.usd")
+    base.Save()
+
+    physics = Usd.Stage.CreateNew(str(root / "payloads" / "myasset_physics.usd"))
+    _define_default_prim(physics)
+    physics.Save()
+
+    main_path = root / "myasset.usda"
+    main = Usd.Stage.CreateNew(str(main_path))
+    default_prim = _define_default_prim(main)
+    Usd.ModelAPI(default_prim).SetKind(Kind.Tokens.component)
+    default_prim.GetReferences().AddReference("./payloads/myasset_base.usd")
+    default_prim.GetPayloads().AddPayload("./payloads/myasset_physics.usd")
+    main.Save()
+
+    return main_path
+
+
+@pytest.fixture(scope="session")
+def unpacked_asset(tmp_path_factory) -> Path:
+    return build_isaac_asset(tmp_path_factory.mktemp("unpacked"))
+
+
+@pytest.fixture(scope="session")
+def usdz_asset(tmp_path_factory) -> Path:
+    """Package the same asset into a single `.usdz` and return its path."""
+    work_dir = tmp_path_factory.mktemp("packaged")
+    main_path = build_isaac_asset(work_dir / "src")
+    usdz_path = work_dir / "myasset.usdz"
+    assert UsdUtils.CreateNewUsdzPackage(Sdf.AssetPath(str(main_path)), str(usdz_path))
+    return usdz_path
+
+
+def test_usdz_payload_layers_are_package_relative(usdz_asset):
+    """Guards the premise of the fix: usdz payloads exist only inside the archive."""
+    assert not (usdz_asset.parent / "payloads").exists()
+
+    stage = Usd.Stage.Open(str(usdz_asset))
+    packaged = [layer.identifier for layer in stage.GetUsedLayers() if ".usdz[" in layer.identifier]
+    assert any("payloads/myasset_base.usd]" in identifier for identifier in packaged)
+    assert any("payloads/myasset_meshes.usd]" in identifier for identifier in packaged)
+    assert any("payloads/myasset_physics.usd]" in identifier for identifier in packaged)
+
+
+def test_packaged_asset_passes(checker_class, usdz_asset):
+    """A correctly composed asset delivered as `.usdz` must pass ISA.001."""
+    stage = Usd.Stage.Open(str(usdz_asset))
+    assert isa_001_failures(checker_class, stage) == []
+
+
+def test_unpacked_asset_passes(checker_class, unpacked_asset):
+    """The same asset as a directory tree must pass identically."""
+    stage = Usd.Stage.Open(str(unpacked_asset))
+    assert isa_001_failures(checker_class, stage) == []
+
+
+def test_packaged_and_unpacked_agree(checker_class, usdz_asset, unpacked_asset):
+    """Packaging must not change the verdict."""
+    packaged = isa_001_failures(checker_class, Usd.Stage.Open(str(usdz_asset)))
+    unpacked = isa_001_failures(checker_class, Usd.Stage.Open(str(unpacked_asset)))
+    assert packaged == unpacked
+
+
+def test_flat_asset_still_fails(checker_class, tmp_path):
+    """An asset with no payload structure at all must still fail."""
+    stage = Usd.Stage.CreateNew(str(tmp_path / "flat.usda"))
+    default_prim = _define_default_prim(stage)
+    Usd.ModelAPI(default_prim).SetKind(Kind.Tokens.component)
+    UsdGeom.Mesh.Define(stage, "/MyAsset/mesh_01")
+    stage.Save()
+
+    failures = isa_001_failures(checker_class, stage)
+    assert failures, "a flat asset must not pass ISA.001"
+    assert any("No recognized Isaac Sim payload structure" in message for message in failures)
+
+
+def build_robot_asset(root: Path, omit: str | None = None) -> Path:
+    """Author the RC.001 robot payload layout, optionally omitting one layer.
+
+    ``Robot-Body-Isaac`` includes ISA.001, so this layout must satisfy the
+    requirement too: ``payloads/base.usda`` referencing ``geometries.usd``,
+    ``instances.usda`` and ``materials.usda``.
+    """
+    (root / "payloads").mkdir(parents=True, exist_ok=True)
+
+    leaf_layers = [name for name in ("geometries.usd", "instances.usda", "materials.usda") if name != omit]
+    for layer_name in leaf_layers:
+        layer = Usd.Stage.CreateNew(str(root / "payloads" / layer_name))
+        _define_default_prim(layer)
+        layer.Save()
+
+    base = Usd.Stage.CreateNew(str(root / "payloads" / "base.usda"))
+    base_prim = _define_default_prim(base)
+    for layer_name in leaf_layers:
+        base_prim.GetReferences().AddReference(f"./{layer_name}", Sdf.Path("/MyAsset"))
+    base.Save()
+
+    main_path = root / "robot.usda"
+    main = Usd.Stage.CreateNew(str(main_path))
+    default_prim = _define_default_prim(main)
+    Usd.ModelAPI(default_prim).SetKind(Kind.Tokens.component)
+    default_prim.GetReferences().AddReference("./payloads/base.usda")
+    main.Save()
+
+    return main_path
+
+
+def test_robot_payload_layout_passes(checker_class, tmp_path):
+    """The robot layout is the other structure ISA.001 accepts."""
+    stage = Usd.Stage.Open(str(build_robot_asset(tmp_path / "robot")))
+    assert isa_001_failures(checker_class, stage) == []
+
+
+def test_partial_robot_layout_fails(checker_class, tmp_path):
+    """A layout that only partly matches is reported against the closest layout."""
+    stage = Usd.Stage.Open(str(build_robot_asset(tmp_path / "partial", omit="materials.usda")))
+
+    failures = isa_001_failures(checker_class, stage)
+    assert failures
+    assert any("robot" in message and "materials" in message for message in failures)
+
+
+def test_missing_component_kind_fails(checker_class, tmp_path):
+    """Default prim kind is still enforced alongside the payload structure."""
+    main_path = build_isaac_asset(tmp_path / "nokind")
+    stage = Usd.Stage.Open(str(main_path))
+    Usd.ModelAPI(stage.GetDefaultPrim()).SetKind(Kind.Tokens.assembly)
+
+    failures = isa_001_failures(checker_class, stage)
+    assert any("component" in message for message in failures)
+
+
+def test_visible_meshes_scope_fails(checker_class, tmp_path):
+    """A visible Meshes/Visuals scope is still reported."""
+    main_path = build_isaac_asset(tmp_path / "visible", meshes_visible=True)
+    stage = Usd.Stage.Open(str(main_path))
+
+    failures = isa_001_failures(checker_class, stage)
+    assert any("invisible" in message for message in failures)
+
+
+@pytest.mark.skipif(not SAMPLE_PROP.exists(), reason="sample_content not fetched (Git LFS)")
+def test_sample_content_prop_passes(checker_class):
+    """The repository's own Isaac-composed sample prop must pass ISA.001.
+
+    This asset uses ``payloads/obs_workbench_tool_01_{base,meshes,physics}.usd``:
+    note the payload stem does not match the main asset file name, which is why
+    the layers are matched by role suffix rather than by exact file name.
+    """
+    stage = Usd.Stage.Open(str(SAMPLE_PROP))
+    assert isa_001_failures(checker_class, stage) == []


### PR DESCRIPTION
## Summary

The `ISA.001` Isaac composition checker inspects the OS filesystem for a hardcoded set of payload filenames. As a result it fails assets that are correctly composed, including this repository's own sample prop.

Both defects are in `nv_core/sr_specs/docs/capabilities/isaac_sim/composition/validation.py`.

**1. The payload check is filesystem-only, so every `.usdz` fails.**
`_check_payload_structure` resolves `Path(stage_root).parent / "payloads"` and calls `.exists()`. A `.usdz` is a single package: its `payloads/` layers are archive members, so there is never a sibling `payloads/` directory on disk and the check fails unconditionally for packaged assets.

**2. The expected filenames are the robot layout, applied to prop assets too.**
The checker expects `["geometries.usd", "base.usda", "instances.usda", "materials.usda"]` and a literal `./payloads/base.usda` reference. That is the robot payload layout. `ISA.001` is also carried by `Prop-Robotics-Isaac` (via `FET100_BASE_ISAACSIM`), and its requirement doc specifies `{asset_name}_base` / `_meshes` / `_physics` — so correctly-authored prop assets fail even unpacked.

Concretely, `sample_content/.../obs_workbench_tool_a01/isaacsim_usd/sm_obs_workbench_tool_a01_01.usd` uses `payloads/obs_workbench_tool_01_{base,meshes,physics}.usd` and fails `ISA.001` on `main` today:

```
  [FAILED] Prop-Robotics-Isaac v1.0.0
           FET100_BASE_ISAACSIM: failing requirements: ['com.nvidia.simready.ISA.001']
```

## What changed

Both checks are now driven by the **composed stage** rather than the surrounding directory listing:

- Payload layers are detected from `stage.GetUsedLayers()`, unioned with the reference/payload arcs authored on the default prim. Layer identifiers cover the on-disk form (`.../payloads/x_base.usd`) and the packaged form (`asset.usdz[payloads/x_base.usd]`) alike, so packaging no longer changes the verdict. Unioning with the arcs also keeps the check correct when a stage is opened with a load rule other than `LoadAll`.
- Layers are matched by **role**, not by exact filename. The payload stem does not have to equal the main asset file name — the sample prop above is `sm_obs_workbench_tool_a01_01.usd` with `obs_workbench_tool_01_*` payloads.
- **Both layouts `ISA.001` governs are accepted**: the prop layout (`payloads/{asset_name}_base.usd` + `_meshes.usd` + `_physics.usd`) and the robot layout used by `Robot-Body-Isaac` (`payloads/base.usda` + `geometries.usd` + `instances.usda` + `materials.usda`). An asset must match one of them completely; a partial structure fails and is reported against the closest layout.

`composition.md` is reconciled with the checker: it names the validator entry point, records that either layout satisfies the requirement, notes the stem/filename independence, and documents that `.usdz` delivery is validated identically.

The `Meshes`/`Visuals` invisibility check is unchanged in intent; it now runs only on scopes actually present in the composed stage, and the dead `found_looks`/`found_meshes`/`found_visuals` bookkeeping and unused imports were removed.

## Verification

Swept every `.usd`/`.usda` under `sample_content` plus 100 packaged SimReady `.usdz` assets — 176 stages — with the checker before and after:

| | `ISA.001` passing |
|---|---|
| before | 1 |
| after | 102 |

**Zero regressions**: no asset that passed before fails now. `ur10.usd`, the one asset passing on `main`, still passes — that case is what motivated accepting both layouts rather than only the prop one.

## Tests

New `nv_core/sr_specs/tests/test_isaac_composition.py` (10 tests, `pytest nv_core/sr_specs/tests/test_isaac_composition.py`) covering:

- a packaged `.usdz` asset passes, and agrees with the identical unpacked tree
- the usdz premise itself — payload layers exist only as archive members
- the robot layout passes; a partial robot layout fails naming the missing layer
- a flat asset with no payload structure still fails
- `kind='component'` and scope-invisibility failures are still reported
- the repository's own sample prop passes

The `.usdz` fixture is built at test time rather than committed: `*.usdz` is a Git LFS pattern here, and constructing it in the test keeps the required layout readable in review. Against the current checker 6 of the 10 tests fail; all 10 pass with this change.

## Note on a related bug not fixed here

`simready-validate`'s `validate_asset()` rejects any path whose extension is not `.usd`/`.usda` and returns `None` silently, so `.usdz` assets produce no verdict from the CLI at all. That lives in the `simready-validate` package rather than this repository, so it is out of scope for this PR, but it compounds the same problem and is worth tracking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
